### PR TITLE
Fix responsiveness profile page

### DIFF
--- a/src/components/receipt/ReceiptRow.tsx
+++ b/src/components/receipt/ReceiptRow.tsx
@@ -48,14 +48,14 @@ const ReceiptRow = ({ receipt }: ReceiptOverviewProps) => {
           </span>
         </div>
       </td>
-      <td className="bg-green-200 text-left font-semibold ">
+      <td className="bg-green-200 text-left font-semibold hidden md:table-cell">
         {receipt.committeeName}
       </td>
       <td className="bg-green-200 text-left ">{receipt.receiptName}</td>
-      <td className="bg-green-200 text-left hidden md:table-cell  font-semibold ">
+      <td className="bg-green-200 text-left hidden lg:table-cell  font-semibold ">
         {receipt.paymentOrCard === "Payment" ? "Utlegg" : "Kort"}
       </td>
-      <td className="bg-green-200 text-left max-h-3 hidden md:table-cell max-w-[150px] overflow-hidden line-clamp-3">
+      <td className="bg-green-200 text-left max-h-3 hidden lg:table-cell max-w-[150px] overflow-hidden line-clamp-3">
         {receipt.receiptDescription.slice(0, 60)}
         {receipt.receiptDescription.length > 60 ? "..." : ""}
       </td>

--- a/src/components/receipt/ReceiptTable.tsx
+++ b/src/components/receipt/ReceiptTable.tsx
@@ -61,16 +61,16 @@ const ReceiptTable = ({
             <thead>
               <tr>
                 <th></th>
-                <th className="text-left text-white text-xl font-normal">
+                <th className="text-left text-white text-xl font-normal hidden md:table-cell">
                   Komité
                 </th>
                 <th className="text-left text-white text-xl font-normal">
                   Anledning
                 </th>
-                <th className="text-left text-white text-xl font-normal hidden md:table-cell">
+                <th className="text-left text-white text-xl font-normal hidden lg:table-cell">
                   Type
                 </th>
-                <th className="text-left text-white text-xl font-normal hidden md:table-cell">
+                <th className="text-left text-white text-xl font-normal hidden lg:table-cell">
                   Kommentar
                 </th>
                 <th className="text-middle w-[110px] text-white text-xl font-normal">

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -36,11 +36,11 @@ const ProfilePage = () => {
     }, [debouncedSearchTerm, receiptStatus]);
 
   return (
-    <div className="flex min-h-screen pt-5">
-      <div className="hidden sm:block lg:block">
+    <div className="flex min-h-screen pt-5 mx-5 gap-x-6">
+      <div className="hidden md:block lg:block">
         <ProfileCard />
       </div>
-      <div className="ml-5 mr-5 rounded-xl flex-grow p-8 bg-[#669782] h-full">
+      <div className="mx-auto rounded-xl w-full p-4 sm:p-6 md:p-8 bg-[#669782] h-full">
         <ReceiptTable
           receipts={receiptData?.receipts}
           receiptsLoading={receiptDataLoading}


### PR DESCRIPTION
Hiding columns like committe name, type and description when screen size (width) gets smaller